### PR TITLE
Modified tests to be compatible with Java 8

### DIFF
--- a/client/src/test/java/com/bazaarvoice/auth/hmac/client/ValidatingHttpServer.java
+++ b/client/src/test/java/com/bazaarvoice/auth/hmac/client/ValidatingHttpServer.java
@@ -73,7 +73,7 @@ public abstract class ValidatingHttpServer implements Container {
     }
 
     public URI getUri() {
-        return UriBuilder.fromUri("http://localhost").port(port).build();
+        return UriBuilder.fromUri("http://localhost/").port(port).build();
     }
 
     private static class Decoder {


### PR DESCRIPTION
So it turns out that the library that we're using for testing the client behaves differently depending on which version of Java is being used.  Specifically, it parses the path of a request differently between Java 7 and Java 8 if the path is empty.  In Java 7, it'll identify the path of a request to "http://localhost" as "", whereas in Java 8, it'll identify the path as "/".  This inconsistency contributes to the HMAC signature differing between the client and server.

Rather than attempt to fix the testing library or be clever on the client side, I've modified the test to avoid this edge case.

Fixes #45 