### PR TITLE
Removed check for available bytes in input stream.

### DIFF
--- a/server/src/main/java/com/bazaarvoice/auth/hmac/server/RequestDecoder.java
+++ b/server/src/main/java/com/bazaarvoice/auth/hmac/server/RequestDecoder.java
@@ -70,14 +70,11 @@ public class RequestDecoder {
         InputStream in = containerRequest.getEntityInputStream();
 
         try {
-            byte[] content = null;
-            if (in.available() > 0) {
-                ReaderWriter.writeTo(in, out);
-                content = out.toByteArray();
+            ReaderWriter.writeTo(in, out);
+            byte[] content = out.toByteArray();
 
-                // Reset the input stream so that it can be read again by another filter or resource
-                containerRequest.setEntityInputStream(new ByteArrayInputStream(content));
-            }
+            // Reset the input stream so that it can be read again by another filter or resource
+            containerRequest.setEntityInputStream(new ByteArrayInputStream(content));
             return content;
 
         } catch (IOException ex) {


### PR DESCRIPTION
The method InputStream.available() by default returns 0 available bytes. It is considered
an estimate and should not be used as a gauge to determine more data should be read. Instead
opting to always read until the end of the stream denoted by a -1 has been reached.