### PR TITLE
chore: use ubuntu trusty dist as CI base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk8
   - openjdk8


### PR DESCRIPTION
oraclejdk8 is no longer available in the Xenial (default) distribution